### PR TITLE
Remove org.eclipse.equinox.launcher.cocoa.macosx link

### DIFF
--- a/org.eclipse.equinox.launcher.cocoa.macosx
+++ b/org.eclipse.equinox.launcher.cocoa.macosx
@@ -1,1 +1,0 @@
-org.eclipse.equinox.launcher.cocoa.macosx.aarch64


### PR DESCRIPTION
The fragment org.eclipse.equinox.launcher.cocoa.macosx is removed in [1] since there are architecture specific replacements now.

[1] - https://github.com/eclipse-equinox/equinox/pull/622